### PR TITLE
Added allocation predicates

### DIFF
--- a/sdk/src/main/java/com/hashicorp/nomad/javasdk/NomadPredicates.java
+++ b/sdk/src/main/java/com/hashicorp/nomad/javasdk/NomadPredicates.java
@@ -127,6 +127,52 @@ public abstract class NomadPredicates {
     }
 
     /**
+     * Regates the check result of a given Predicate.
+     */
+    public static <T> Predicate<T> not(final Predicate<T> a) {
+        return new Predicate<T>() {
+            @Override
+            public boolean apply(T value) {
+                return !a.apply(value);
+            }
+        };
+    }
+
+    /**
+     * Returns a Predicate that checks if any of the Predicates of a given list evaluate to true.
+     */
+    public static <T> Predicate<T> any(final List<Predicate<T>> as) {
+        return new Predicate<T>() {
+            @Override
+            public boolean apply(T value) {
+                for (Predicate<? super T> a : as) {
+                    if (a.apply(value)) {
+                        return true;
+                    }
+                }
+                return false;
+            }
+        };
+    }
+
+    /**
+     * Returns a Predicate that checks if all of the Predicates of a given list evaluate to true.
+     */
+    public static <T> Predicate<T> all(final List<Predicate<T>> as) {
+        return new Predicate<T>() {
+            @Override
+            public boolean apply(T value) {
+                for (Predicate<? super T> a : as) {
+                    if (!a.apply(value)) {
+                        return false;
+                    }
+                }
+                return true;
+            }
+        };
+    }
+
+    /**
      * Returns a predicate that checks if allocation has the given client status.
      */
     public static Predicate<AllocationListStub> allocationHasClientStatus(final String status) {
@@ -172,26 +218,6 @@ public abstract class NomadPredicates {
                     }
                 }
                 return true;
-            }
-        };
-    }
-
-    /**
-     * Returns a predicate that checks if more than a given percentage of allocations finished with status "failed".
-     */
-    public static Predicate<List<AllocationListStub>> failedAllocationsOver(final Long threshold) {
-        return new Predicate<List<AllocationListStub>>() {
-            @Override
-            public boolean apply(List<AllocationListStub> allocs) {
-                long failed = 0;
-                for (AllocationListStub alloc : allocs) {
-                    if (allocationHasFailed().apply(alloc)) {
-                        failed++;
-                    }
-                }
-                long total = allocs.size();
-                long failPct = (long) ((float) failed / total * 100);
-                return failPct > threshold;
             }
         };
     }

--- a/sdk/src/test/java/com/hashicorp/nomad/javasdk/NomadPredicatesTest.java
+++ b/sdk/src/test/java/com/hashicorp/nomad/javasdk/NomadPredicatesTest.java
@@ -1,0 +1,107 @@
+package io.github.valfadeev.rundeck_nomad_plugin.nomad;
+
+import java.util.List;
+import java.util.ArrayList;
+import com.hashicorp.nomad.javasdk.Predicate;
+
+import com.hashicorp.nomad.apimodel.AllocationListStub;
+import org.junit.Test;
+
+import static io.github.valfadeev.rundeck_nomad_plugin.nomad.NomadAllocationPredicates.*;
+import static org.junit.Assert.*;
+import static org.hamcrest.CoreMatchers.*;
+
+public class NomadAllocationPredicateTest {
+
+
+    private static Predicate<AllocationListStub> allocationHasClientDescription(final String description) {
+        return allocationListStub -> description.equals(allocationListStub.getClientDescription());
+    }
+
+    private static Predicate<AllocationListStub> allocationHasTestDescription() {
+        return allocationHasClientDescription("test");
+    }
+
+    @Test
+    public void shouldEvaluatePredicateChecks() throws Exception {
+
+      AllocationListStub pending = new AllocationListStub()
+              .setClientStatus("pending");
+      AllocationListStub running = new AllocationListStub()
+              .setClientStatus("running");
+      AllocationListStub failed1 = new AllocationListStub()
+              .setClientStatus("failed");
+      AllocationListStub failed2 = new AllocationListStub()
+              .setClientStatus("failed");
+      AllocationListStub lost = new AllocationListStub()
+              .setClientStatus("lost");
+      AllocationListStub complete = new AllocationListStub()
+              .setClientStatus("complete")
+              .setClientDescription("test");
+
+      List<AllocationListStub> finished = new ArrayList<>();
+      finished.add(failed1);
+      finished.add(lost);
+      finished.add(complete);
+
+      List<AllocationListStub> notFinished = new ArrayList<>();
+      notFinished.add(pending);
+      notFinished.add(running);
+      notFinished.add(complete);
+      notFinished.add(failed2);
+
+      List<AllocationListStub> failedOver = new ArrayList<>();
+      failedOver.add(failed1);
+      failedOver.add(complete);
+      failedOver.add(failed2);
+
+      List<Predicate<AllocationListStub>> finishedP = new ArrayList<>();
+      finishedP.add(allocationHasBeenLost());
+      finishedP.add(allocationHasCompleted());
+      finishedP.add(allocationHasFailed());
+
+      List<Predicate<AllocationListStub>> unfinishedP = new ArrayList<>();
+      unfinishedP.add(allocationIsPending());
+      unfinishedP.add(allocationIsRunning());
+
+      List<Predicate<AllocationListStub>> testP = new ArrayList<>();
+      testP.add(allocationHasCompleted());
+      testP.add(allocationHasTestDescription());
+      Predicate<AllocationListStub> allTestP = all(testP);
+
+      Predicate<AllocationListStub> anyFinishedP = any(finishedP);
+      Predicate<AllocationListStub> anyUnfinishedP = any(unfinishedP);
+      Predicate<AllocationListStub> notAnyUnFinishedP = not(anyUnfinishedP);
+
+
+      assertThat(allocationHasBeenLost().apply(lost), is(true));
+      assertThat(allocationHasCompleted().apply(complete), is(true));
+      assertThat(allocationHasFailed().apply(failed2), is(true));
+
+      assertThat(allocationFinishedRunning().apply(failed1), is(true));
+      assertThat(allocationFinishedRunning().apply(lost), is(true));
+      assertThat(allocationFinishedRunning().apply(complete), is(true));
+      assertThat(allocationFinishedRunning().apply(pending), is(false));
+      assertThat(allocationFinishedRunning().apply(running), is(false));
+
+      assertThat(anyUnfinishedP.apply(pending), is(true));
+      assertThat(anyUnfinishedP.apply(running), is(true));
+
+      assertThat(anyFinishedP.apply(complete), is(true));
+      assertThat(anyFinishedP.apply(complete), is(true));
+      assertThat(anyFinishedP.apply(complete), is(true));
+
+      assertThat(allTestP.apply(complete), is(true));
+
+      assertThat(notAnyUnFinishedP.apply(complete), is(true));
+      assertThat(notAnyUnFinishedP.apply(failed1), is(true));
+      assertThat(notAnyUnFinishedP.apply(lost), is(true));
+
+      assertThat(allAllocationsFinished().apply(finished), is(true));
+      assertThat(allAllocationsFinished().apply(notFinished), is(false));
+
+      assertThat(failedAllocationsOver(50L).apply(failedOver), is(true));
+
+    }
+}
+


### PR DESCRIPTION
First of all, thank you for a great library! I managed to build a small integration [project](https://github.com/ValFadeev/rundeck-nomad-plugin) with the help of it. In the process found it  handy to implement some more `Predicate`s for the purpose of monitoring allocation status.

While some of those may feel a bit too specific, I thought they might be useful for other users of the SDK.

[Here](https://github.com/ValFadeev/rundeck-nomad-plugin/blob/master/src/main/java/io/github/valfadeev/rundeck_nomad_plugin/NomadStepPlugin.java#L200) is the line where I apply the new predicates in query options.