### PR TITLE
Fix build errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -72,6 +72,11 @@
                 <version>4.5.3</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpclient-cache</artifactId>
+                <version>4.5.3</version>
+            </dependency>
+            <dependency>
                 <groupId>org.bouncycastle</groupId>
                 <artifactId>bcpkix-jdk15on</artifactId>
                 <version>1.56</version>

--- a/sdk/pom.xml
+++ b/sdk/pom.xml
@@ -41,6 +41,11 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient-cache</artifactId>
+        </dependency>
+
+        <dependency>
             <groupId>org.bouncycastle</groupId>
             <artifactId>bcpkix-jdk15on</artifactId>
         </dependency>

--- a/sdk/src/main/java/com/hashicorp/nomad/javasdk/JobsApi.java
+++ b/sdk/src/main/java/com/hashicorp/nomad/javasdk/JobsApi.java
@@ -72,10 +72,24 @@ public class JobsApi extends ApiBase {
      * @param jobId ID of the job to deregister
      * @throws IOException    if there is an HTTP or lower-level problem
      * @throws NomadException if the response signals an error or cannot be deserialized
-     * @see <a href="https://www.nomadproject.io/docs/http/job.html#delete">{@code DELETE /v1/job/<ID>}</a>
+     * @see <a href="https://www.nomadproject.io/api/jobs.html#stop-a-job">{@code DELETE /v1/job/<ID>}</a>
      */
     public EvaluationResponse deregister(final String jobId) throws IOException, NomadException {
-        return deregister(jobId, null);
+        return deregister(jobId, false, null);
+    }
+
+    /**
+     * Deregisters a job in the active region, and stops all allocations that are part of it.
+     *
+     * @param jobId ID of the job to deregister
+     * @param purge specifies that the job should stopped and purged immediately
+     * @throws IOException    if there is an HTTP or lower-level problem
+     * @throws NomadException if the response signals an error or cannot be deserialized
+     * @see <a href="https://www.nomadproject.io/api/jobs.html#stop-a-job">{@code DELETE /v1/job/<ID>}</a>
+     */
+    public EvaluationResponse deregister(final String jobId, @Nullable Boolean purge)
+        throws IOException, NomadException {
+        return deregister(jobId, purge, null);
     }
 
     /**
@@ -84,14 +98,21 @@ public class JobsApi extends ApiBase {
      *
      * @param jobId   the ID of the job to deregister
      * @param options options controlling how the request is performed
+     * @param purge specifies that the job should stopped and purged immediately
      * @throws IOException    if there is an HTTP or lower-level problem
      * @throws NomadException if the response signals an error or cannot be deserialized
-     * @see <a href="https://www.nomadproject.io/docs/http/job.html#delete">{@code DELETE /v1/job/<ID>}</a>
+     * @see <a href="https://www.nomadproject.io/api/jobs.html#stop-a-job">{@code DELETE /v1/job/<ID>}</a>
      */
-    public EvaluationResponse deregister(final String jobId, @Nullable final WriteOptions options)
+    public EvaluationResponse deregister(final String jobId,
+                                         @Nullable Boolean purge,
+                                         @Nullable final WriteOptions options)
             throws IOException, NomadException {
+        RequestBuilder builder = delete("/v1/job/" + jobId, options);
+        if (purge != null) {
+          builder.addParameter("purge", purge.toString());
+        }
+        return executeEvaluationCreatingRequest(builder);
 
-        return executeEvaluationCreatingRequest(delete("/v1/job/" + jobId, options));
     }
 
     /**

--- a/sdk/src/main/java/com/hashicorp/nomad/javasdk/NomadApiClient.java
+++ b/sdk/src/main/java/com/hashicorp/nomad/javasdk/NomadApiClient.java
@@ -5,6 +5,8 @@ import com.hashicorp.nomad.apimodel.NodeListStub;
 import org.apache.http.HttpHost;
 import org.apache.http.HttpRequest;
 import org.apache.http.HttpStatus;
+import org.apache.http.protocol.HttpContext;
+import org.apache.http.client.protocol.HttpClientContext;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.methods.RequestBuilder;
@@ -305,7 +307,16 @@ public final class NomadApiClient implements Closeable, AutoCloseable {
                 .setRetryHandler(new DefaultHttpRequestRetryHandler() {
                     @Override
                     protected boolean handleAsIdempotent(HttpRequest request) {
+                        return false;
+                    }
+                    @Override
+                    public boolean retryRequest(final IOException exception,
+                                                   final int executionCount,
+                                                   final HttpContext context) {
                         return true;
+                        final HttpClientContext clientContext = HttpClientContext.adapt(context);
+                        final HttpRequest request = clientContext.getRequest();
+                        return handleAsIdempotent(request);
                     }
                 })
                 .setSSLContext(buildSslContext(config.getTls()))

--- a/sdk/src/main/java/com/hashicorp/nomad/javasdk/NomadApiClient.java
+++ b/sdk/src/main/java/com/hashicorp/nomad/javasdk/NomadApiClient.java
@@ -12,7 +12,9 @@ import org.apache.http.client.methods.HttpUriRequest;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.DefaultHttpRequestRetryHandler;
-import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.impl.client.cache.CachingHttpClientBuilder;
+import org.apache.http.impl.client.cache.CacheConfig;
+import org.apache.http.impl.client.cache.ExponentialBackOffSchedulingStrategy;
 
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
@@ -302,8 +304,9 @@ public final class NomadApiClient implements Closeable, AutoCloseable {
     }
 
     private CloseableHttpClient buildHttpClient(NomadApiConfiguration config) {
-
-        return HttpClientBuilder.create()
+        return CachingHttpClientBuilder
+                .create()
+                .setSchedulingStrategy(new ExponentialBackOffSchedulingStrategy(CacheConfig.DEFAULT))
                 .setRetryHandler(new DefaultHttpRequestRetryHandler() {
                     @Override
                     protected boolean handleAsIdempotent(HttpRequest request) {

--- a/sdk/src/main/java/com/hashicorp/nomad/javasdk/NomadApiClient.java
+++ b/sdk/src/main/java/com/hashicorp/nomad/javasdk/NomadApiClient.java
@@ -307,13 +307,12 @@ public final class NomadApiClient implements Closeable, AutoCloseable {
                 .setRetryHandler(new DefaultHttpRequestRetryHandler() {
                     @Override
                     protected boolean handleAsIdempotent(HttpRequest request) {
-                        return false;
+                        return true;
                     }
                     @Override
                     public boolean retryRequest(final IOException exception,
                                                    final int executionCount,
                                                    final HttpContext context) {
-                        return true;
                         final HttpClientContext clientContext = HttpClientContext.adapt(context);
                         final HttpRequest request = clientContext.getRequest();
                         return handleAsIdempotent(request);

--- a/testkit/src/test/java/com/hashicorp/nomad/javasdk/JobsApiTest.java
+++ b/testkit/src/test/java/com/hashicorp/nomad/javasdk/JobsApiTest.java
@@ -230,6 +230,12 @@ public class JobsApiTest extends ApiTestBase {
             Evaluation evaluation = agent.getApiClient().getEvaluationsApi().pollForCompletion(deregisterResponse, waitStrategyForTest()).getValue();
             assertThat(evaluation.getNextEval(), emptyOrNullString());
 
+            assertThat("job ID", jobsApi.info(job.getId()).getValue().getId(), nonEmptyString());
+
+            EvaluationResponse deregisterAndPurgeResponse = jobsApi.deregister(job.getId(), true);
+            assertUpdatedServerResponse(deregisterAndPurgeResponse);
+            assertThat("evaluation ID", deregisterAndPurgeResponse.getValue(), nonEmptyString());
+
             new ErrorResponseAssertion("job not found") {
                 @Override
                 protected NomadResponse<?> performRequest() throws IOException, NomadException {


### PR DESCRIPTION
As discussed in https://github.com/hashicorp/nomad-java-sdk/pull/2 this is an attempt to fix the failing build. It turned out the tests were failing because of the change to the job deregistration API introduced in https://github.com/hashicorp/nomad/commit/950171f094d7bb45c8313f45c50099b91f36d36f whereby jobs remain queryable until the next GC run, unless `purge=true` is explicitly set by the caller.
Unfortunately, now Travis is killing the build because logs exceed the 4MB limit. Since most of the lines arise from connection retries, I tried to fix this by adding a backoff strategy, however that has not helped much.