### PR TITLE
Changed endpoint for Job Validation

### DIFF
--- a/sdk/src/main/java/com/hashicorp/nomad/javasdk/JobsApi.java
+++ b/sdk/src/main/java/com/hashicorp/nomad/javasdk/JobsApi.java
@@ -721,7 +721,7 @@ public class JobsApi extends ApiBase {
     public ServerResponse<JobValidateResponse> validate(Job job, @Nullable WriteOptions options)
             throws IOException, NomadException {
         return executeServerAction(
-                put("/v1/job/validate", new JobValidationRequest(job), options),
+                put("/v1/validate/job", new JobValidationRequest(job), options),
                 NomadJson.parserFor(JobValidateResponse.class));
     }
 


### PR DESCRIPTION
The correct endpoint for validating a JSON Job is /v1/validate/job. The current implementation looks for a job with name "validate" at /v1/job/validate.