### PR TITLE
Fix date deserialization issue

### DIFF
--- a/sdk/src/main/java/com/hashicorp/nomad/javasdk/CustomDateDeserializer.java
+++ b/sdk/src/main/java/com/hashicorp/nomad/javasdk/CustomDateDeserializer.java
@@ -1,0 +1,54 @@
+package com.hashicorp.nomad.javasdk;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonTokenId;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.util.ISO8601Utils;
+
+import java.io.IOException;
+import java.text.ParsePosition;
+import java.util.Date;
+
+/**
+ * Custom deserializer to parse dates in iso8601 format. This is much much faster and GC friendly than using
+ * SimpleDateFormat so highly suitable to (un)serialize lots of date objects. Also it help to fix date parsing
+ * issue in iso8601 format.
+ *
+ * Supported parse format: [yyyy-MM-dd|yyyyMMdd][T(hh:mm[:ss[.sss]]|hhmm[ss[.sss]])]?[Z|[+-]hh[:]mm]]
+ *
+ *
+ * Fix: issue#32: Failed to deserialize timestamp with non-UTC time zone.
+ *
+ * @see <a href="http://www.w3.org/TR/NOTE-datetime">this specification</a>
+ */
+public class CustomDateDeserializer extends StdDeserializer<Date> {
+    /**
+     * Default constructor.
+     */
+    public CustomDateDeserializer() {
+        this(Date.class);
+    }
+
+    /**
+     * Constructor with class parameter.
+     *
+     * @param vc class parameter
+     */
+    public CustomDateDeserializer(Class<?> vc) {
+        super(vc);
+    }
+
+    @Override
+    public Date deserialize(JsonParser jp, DeserializationContext ctxt) throws IOException {
+        if (jp.getCurrentTokenId() == JsonTokenId.ID_STRING) {
+            try {
+                return ISO8601Utils.parse(jp.getText(), new ParsePosition(0));
+            } catch (Exception e) {
+                throw new IOException(e);
+            }
+        } else {
+            throw new IOException("Unparseable data which is expected as STRING: " + jp.getCurrentToken().toString());
+        }
+    }
+}

--- a/sdk/src/main/java/com/hashicorp/nomad/javasdk/NomadJson.java
+++ b/sdk/src/main/java/com/hashicorp/nomad/javasdk/NomadJson.java
@@ -6,12 +6,14 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.hashicorp.nomad.apimodel.Job;
 
 import java.io.IOException;
 import java.text.SimpleDateFormat;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.Date;
 import java.util.List;
 
 import static com.fasterxml.jackson.databind.PropertyNamingStrategy.UPPER_CAMEL_CASE;
@@ -29,6 +31,11 @@ public abstract class NomadJson {
             .disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES);
 
     static {
+        // Use customize module to deserialize Date.class in iso8601 format.
+        SimpleModule simpleModule = new SimpleModule();
+        simpleModule.addDeserializer(Date.class, new CustomDateDeserializer());
+        OBJECT_MAPPER.registerModule(simpleModule);
+
         OBJECT_MAPPER.setConfig(
                 OBJECT_MAPPER.getSerializationConfig()
                         .with(new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"))


### PR DESCRIPTION
Fix: Failed to deserialize timestamp with non-UTC time zone #32

Current implementation could not correct deserialize "2020-03-15T10:28:05.192414616+08:00" back to <code>java.util.Date</code> object. To resolve this issue, <code>CustomDateDeserializer</code> class extends <code>com.fasterxml.jackson.databind.deser.std.StdDeserializer</code> and utilize <code>ISO8601Utils</code> to parse ISO8601 format string back to Date.
